### PR TITLE
Configurable Guzzle client timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ $notifier = new Faultline\Notifier([
     'project' => 'faultline-php',
     'apiKey' => 'xxxxXXXXXxXxXXxxXXXXXXXxxxxXXXXXX',
     'endpoint' => 'https://xxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/v0',
+    'timeout' => '30.0',
     'notifications' => [
         [
             'type'=> 'slack',

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -69,7 +69,7 @@ class Notifier extends \Airbrake\Notifier
                 'x-api-key' => $this->opt['apiKey']
             ],
             'json' => $notice,
-            'timeout'  => 5.0,
+            'timeout'  => (isset($this->opt['timeout']) ? $this->opt['timeout'] : 5.0),
         ];
         if (preg_match('/^5/', \GuzzleHttp\Client::VERSION)) {
             $config['exceptions'] = false;

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -17,6 +17,7 @@ class NotifierTest extends TestCase
             'project' => 'faultline-test',
             'apiKey' => 'xxxxXXXXXxXxXXxxXXXXXXXxxxxXXXXXX',
             'endpoint' => 'https://xxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/v0',
+            'timeout' => '30.0',
             'notifications' => [
                 [
                     'type'=> 'slack',
@@ -49,6 +50,7 @@ class NotifierTest extends TestCase
             'project' => 'faultline-test',
             'apiKey' => 'xxxxXXXXXxXxXXxxXXXXXXXxxxxXXXXXX',
             'endpoint' => 'https://example.com/v0',
+            'timeout' => '30.0',
             'notifications' => [
                 [
                     'type'=> 'slack',


### PR DESCRIPTION
Now Guzzle client timeout is set fix value `5.0` in `Notifier::postNotice()`.
https://github.com/faultline/faultline-php/blob/0253bb60467ae250a49767cbb0fb5703ba8820ca/src/Notifier.php#L63-L72

But we want to change timeout value.
So this PR changes Guzzle client timeout to configurable.